### PR TITLE
Add gyroscope-only 360 image viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # 360Viewer
+Visualizador simples de imagem 360 controlado apenas pelo giroscópio.
 
-Visualizador simples de imagens 360 (equiretangular e cubemap) construído com Three.js.
-
-## Recursos
-
-- Arraste para girar, pinça ou rolagem para zoom e tecla **F** para tela cheia.
-- Suporte a giroscópio em dispositivos móveis: após tocar na tela, o panorama acompanha a orientação do aparelho.
-
+## Uso
+Abra o arquivo `index.html` em um dispositivo móvel e movimente o aparelho para explorar a cena.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+  <meta charset="UTF-8" />
+  <title>Visualizador 360° com Giroscópio</title>
+  <style>
+    body { margin: 0; overflow: hidden; }
+    canvas { display: block; }
+  </style>
+</head>
+<body>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.150.1/build/three.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.150.1/examples/js/controls/DeviceOrientationControls.js"></script>
+  <script>
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    document.body.appendChild(renderer.domElement);
+
+    const geometry = new THREE.SphereGeometry(50, 60, 40);
+    geometry.scale(-1, 1, 1);
+
+    const loader = new THREE.TextureLoader();
+    loader.load(
+      'https://reaisevirtuais.com/wp-content/uploads/2020/10/foto-360_1.jpg',
+      texture => {
+        const material = new THREE.MeshBasicMaterial({ map: texture });
+        const mesh = new THREE.Mesh(geometry, material);
+        scene.add(mesh);
+        animate();
+      }
+    );
+
+    const controls = new THREE.DeviceOrientationControls(camera);
+
+    function animate() {
+      requestAnimationFrame(animate);
+      controls.update();
+      renderer.render(scene, camera);
+    }
+
+    window.addEventListener('resize', () => {
+      camera.aspect = window.innerWidth / window.innerHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(window.innerWidth, window.innerHeight);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Build HTML viewer that renders equirectangular panorama using Three.js
- Use DeviceOrientationControls to navigate with mobile gyroscope
- Update README with usage instructions

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c8215acca083238400d21950b0052f